### PR TITLE
Fix: AttributeError in robot_logic due to memos being a list

### DIFF
--- a/pcrb/controller.py
+++ b/pcrb/controller.py
@@ -8,8 +8,8 @@ class GameController:
             self, max_turn=100, x_max=9, y_max=7, robot1_initial_position=None, robot2_initial_position=None):
         self.robot1 = None
         self.robot2 = None
-        self.memos1 = None
-        self.memos2 = None
+        self.memos1 = {}
+        self.memos2 = {}
         self.turn = 0
         self.max_turn = max_turn
         self.x_max = x_max
@@ -30,8 +30,8 @@ class GameController:
     def set_robots(self, robot1, robot2):
         self.robot1 = robot1
         self.robot2 = robot2
-        self.memos1 = []
-        self.memos2 = []
+        self.memos1 = {}
+        self.memos2 = {}
         self.save_game_state(None, None)
         self.turn += 1
 
@@ -86,9 +86,9 @@ class GameController:
         action = adjust_action(action)
 
         if robot == self.robot1:
-            self.memos1.append(memo)
+            self.memos1.update(memo)
         else:
-            self.memos2.append(memo)
+            self.memos2.update(memo)
 
         if robot.stun_counter > 0:
             return "stun"
@@ -200,8 +200,8 @@ class GameController:
 
         # 1) ターンとメモをクリア
         self.turn   = 0
-        self.memos1 = []
-        self.memos2 = []
+        self.memos1 = {}
+        self.memos2 = {}
 
         # 2) ロボットを初期位置・初期ステータスに戻す
         for robot, init_pos in (


### PR DESCRIPTION
Changed GameController to handle memos as a dictionary instead of a list. This allows robot_logic to use dictionary methods like .get() on the memos object.

- Initialized memos1 and memos2 as empty dictionaries in __init__, set_robots, and reset methods.
- Updated run_logic to use `memos.update(memo)` instead of `memos.append(memo)`.